### PR TITLE
Send numpy arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changes for ds9samp
+
+## Version 0.0.3 - 2025-01-24
+
+Added the `send_array` method to allow users to send a NumPy array
+directly to DS9. Added this
+[changelog](https://github.com/cxcsds/ds9samp/blob/main/CHANGELOG.md).
+
+## Version 0.0.2 - 2025-01-17
+
+A documentation release:
+
+- added a note about the
+[astropy-samp-ds9](https://pypi.org/project/astropy-samp-ds9/) Python
+version that was released at essentially the same time as `ds9samp`;
+
+- added links to some of the tools and systems we talk about;
+
+- and additions and improvements to the README.
+
+## Version 0.0.1 - 2024-12-20
+
+Initial version.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![PyPI version](https://badge.fury.io/py/ds9samp.svg)](https://badge.fury.io/py/ds9samp)
+
 # DS9 and Python
 
 [DS9](https://ds9.si.edu/) can be controlled with XPA and

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ which accepts the client name reported by `ds9samp_list`.
 
 ## Examples
 
-These examples are based on the examples in the
+Some of these examples are based on the examples in the
 [DS9+Astropy
 page](https://sites.google.com/cfa.harvard.edu/saoimageds9/ds9-astropy).
 
@@ -364,3 +364,38 @@ with ds9samp() as ds9:
 If a `get` call returns a value then it is returned as a string,
 and the format depends on the command (in this case a pair of
 space-separated coordinates).
+
+### Sending a NumPy array
+
+Version 0.0.3 added the `send_array` call, which will create a
+temporary file and use that to send a NumPy array to DS9. As an
+example, view this 2D elliptical gaussian:
+
+```python
+import numpy as np
+import ds9samp
+
+# Create a rotated elliptical gaussian
+x0 = 2200
+x1 = 3510
+theta = 1.2
+ellip = 0.4
+fwhm = 400
+
+# The grid is x=2000...2500 and y=3000...4000 (inclusive).
+#
+x1s, x0s = np.mgrid[3000:4001, 2000:2501]
+
+# Create the "delta" values
+dx0 = (x0s - x0) * np.cos(theta) + (x1s - x1) * np.sin(theta)
+dx1 = (x1s - x1) * np.cos(theta) - (x0s - x0) * np.sin(theta)
+
+# Create the gaussian image
+r2 = ((dx0 * (1 - ellip))**2  + dx1**2) / (fwhm * (1 - ellip))**2
+img = np.exp(-4 * np.log(2) * r2)
+
+# Send it to DS9
+with ds9samp.ds9samp() as ds9:
+    ds9.send_array(img)
+    ds9.set("cmap viridis")
+```

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ code. The `ds9` attribute of the object returned by either
 if you feel the need to use it.
 
 The `client` attribute gives the name of the DS9 instance, as set by
-the SAMP hub, and the `metadata` attrbute is a dictionary of the
+the SAMP hub, and the `metadata` attribute is a dictionary of the
 metadata reported by the DS9 instance. For example:
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ds9samp"
-version = "0.0.2"
+version = "0.0.3"
 authors = [
   { name = "Douglas Burke", email="dburke@cfa.harvard.edu" }
 ]
@@ -13,7 +13,8 @@ readme = "README.md"
 
 requires-python = ">=3.10"
 dependencies = [
-  "astropy"
+  "astropy",
+  "numpy>=1.20"
 ]
 
 classifiers = [

--- a/src/ds9samp/__init__.py
+++ b/src/ds9samp/__init__.py
@@ -10,8 +10,7 @@ assumes certain things, such as:
 - and commands are to be executed synchronously (i.e. each command is
   executed and acknowledged by DS9 before the next command is processed).
 
-For more complex cases see the `DS9 SAMP documentation <See
-https://sites.google.com/cfa.harvard.edu/saoimageds9/ds9-astropy>`_
+For more complex cases see the `DS9 SAMP documentation <https://sites.google.com/cfa.harvard.edu/saoimageds9/ds9-astropy>`_
 and the `AstroPy SAMP module
 <https://docs.astropy.org/en/stable/samp/>`_.
 

--- a/src/ds9samp/scripts.py
+++ b/src/ds9samp/scripts.py
@@ -17,6 +17,8 @@ from ds9samp import ds9samp, list_ds9, VERSION
 
 
 def parse(desc):
+    """Common parser"""
+
     usage = "%(prog)s [options] command"
     parser = ArgumentParser(usage=usage, description=desc,
                             formatter_class=RawDescriptionHelpFormatter)
@@ -145,7 +147,7 @@ Examples:
         # Special case "@-" to mean stdin
         if args.command == "@-":
             if args.debug:
-                debug(f"Reading commands from stdin")
+                debug("Reading commands from stdin")
 
             commands = sys.stdin.read().split('\n')
 
@@ -153,7 +155,8 @@ Examples:
             if args.debug:
                 debug(f"Reading commands from {args.command[1:]}")
 
-            with open(args.command[1:], mode="rt") as fh:
+            # SAMP commands look to be ASCII not UTF-8.
+            with open(args.command[1:], encoding="ascii", mode="rt") as fh:
                 commands = fh.read().split('\n')
 
     else:
@@ -194,7 +197,7 @@ Examples:
                             formatter_class=RawDescriptionHelpFormatter)
     parser.add_argument("--version", action="version", version=VERSION)
 
-    args = parser.parse_args()
+    parser.parse_args()
 
     clients = list_ds9()
     nclients = len(clients)


### PR DESCRIPTION
Add a `send_array` method as a *simple* way to send a NumPy array to DS9.

Some documentation fixes.

Add a changelog.

Enforce 'numpy >= 1.20'.