### PR TITLE
Add the version number to error messages from scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changes for ds9samp
 
+## Version 0.0.4 - 2025-01-27
+
+The command-line tools now include the package version number when
+reporting an error. For example:
+
+    % ds9samp_list
+    # ds9samp_list (0.0.4): ERROR Unable to find a running SAMP Hub.
+
 ## Version 0.0.3 - 2025-01-24
 
 Added the `send_array` method to allow users to send a NumPy array

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ If the hub can be queried then the "client name" for the DS9 instance
 to use can be found, otherwise the ds9samp_list script can be used:
 
 ```
-% There are 2 DS9 clients: c1 c4
+There are 2 DS9 clients: c1 c4
 ```
 
 Unfortunately there's no easy way to tell which is which. You can try

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ds9samp"
-version = "0.0.3"
+version = "0.0.4"
 authors = [
   { name = "Douglas Burke", email="dburke@cfa.harvard.edu" }
 ]

--- a/src/ds9samp/scripts.py
+++ b/src/ds9samp/scripts.py
@@ -67,7 +67,7 @@ def handle_error(name):
             try:
                 return fn(*args, **kwargs)
             except Exception as exc:
-                emsg = add_color(f"# ds9samp_{name}:") + \
+                emsg = add_color(f"# ds9samp_{name} ({VERSION}):") + \
                     f" ERROR {exc}\n"
                 sys.stderr.write(emsg)
                 sys.exit(1)


### PR DESCRIPTION
This makes the scripts behave a bit-more like CIAO scripts and tools, but there is not going to be a huge attempt to mirror the CIAO behaviour.