### PR TITLE
3d support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes for ds9samp
 
+## Version 0.0.6 - 2025-01-28
+
+The `send_array` and `retrieve_array` methods can now handle 3D arrays
+as well as 2D ones.
+
 ## Version 0.0.5 - 2025-01-27
 
 Added the `retrieve_array` method, which saves the current frame to a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Version 0.0.6 - 2025-01-28
 
 The `send_array` and `retrieve_array` methods can now handle 3D arrays
-as well as 2D ones.
+as well as 2D ones. Data in RGB, HLS, or HSV format is identified by
+setting the `cube` argument in `send_array` to one of: `Cube.RGB`,
+`Cube.HLS`, or `Cube.HSV`.
 
 Commands which return data via a url, such as "data", will now return
 the contents of this file, rather than returning `None` (this is only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 The `send_array` and `retrieve_array` methods can now handle 3D arrays
 as well as 2D ones.
 
+The ds9 connection has now gained a debug field which can be set to
+`True` to display the SAMP return value for each `set` or `get` call.
+
 ## Version 0.0.5 - 2025-01-27
 
 Added the `retrieve_array` method, which saves the current frame to a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 The `send_array` and `retrieve_array` methods can now handle 3D arrays
 as well as 2D ones.
 
+Commands which return data via a url, such as "data", will now return
+the contents of this file, rather than returning `None` (this is only
+valid for `get` calls).
+
 The ds9 connection has now gained a debug field which can be set to
 `True` to display the SAMP return value for each `set` or `get` call.
 

--- a/README.md
+++ b/README.md
@@ -361,11 +361,48 @@ with ds9samp() as ds9:
     x, y = [float(c) for c in coord.split()]
     print(f" -> '{coord}'")
     print(f" -> x={x}  y={y}")
+
+    # Extract pixel data around this location, using a box size of 0.7
+    # arcseconds.
+    #
+    size = 0.7 / 3600
+    vals = ds9.get("data wcs {x} {y} {size:.5f} {size:.5f} no")
+    print("Data values:")
+    print(vals)
 ```
 
-If a `get` call returns a value then it is returned as a string,
-and the format depends on the command (in this case a pair of
-space-separated coordinates).
+If a `get` call returns a value then it is returned as a string, and
+the format depends on the command, in this case a pair of
+space-separated coordinates, for `imexam`. The return value for `data`
+depends on the last argument (in this case `no`, which means the pixel
+coordinates are included).
+
+An example output of this is:
+
+```
+Click anwhere in the image
+ -> '202.4845615 47.1919416'
+ -> x=202.4845615  y=47.1919416
+Data values:
+202.4843826,47.1918298 = 20
+202.4845067,47.1919821 = 33
+202.4844518,47.1920227 = 23
+202.4843373,47.1920259 = 21
+202.4844422,47.1918671 = 24
+202.4843325,47.1919481 = 21
+202.4843874,47.1919076 = 21
+202.4843277,47.1918703 = 20
+202.4845615,47.1919416 = 68
+202.4842181,47.1919514 = 22
+202.4842729,47.1919109 = 22
+202.4843970,47.1920632 = 19
+202.4845019,47.1919043 = 34
+202.4842777,47.1919887 = 21
+202.4844470,47.1919449 = 24
+202.4843922,47.1919854 = 21
+
+
+```
 
 ### Sending a NumPy array
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ds9samp"
-version = "0.0.5"
+version = "0.0.6"
 authors = [
   { name = "Douglas Burke", email="dburke@cfa.harvard.edu" }
 ]

--- a/scripts/imexam.py
+++ b/scripts/imexam.py
@@ -9,3 +9,11 @@ with ds9samp() as ds9:
     x, y = [float(c) for c in coord.split()]
     print(f" -> '{coord}'")
     print(f" -> x={x}  y={y}")
+
+    # Extract pixel data around this location, using a box size of 0.7
+    # arcseconds.
+    #
+    size = 0.7 / 3600
+    vals = ds9.get(f"data wcs {x} {y} {size:.5f} {size:.5f} no")
+    print("Data values:")
+    print(vals)

--- a/src/ds9samp/__init__.py
+++ b/src/ds9samp/__init__.py
@@ -142,7 +142,7 @@ from urllib.parse import urlparse
 
 import numpy as np
 
-from astropy import samp
+from astropy import samp  # type: ignore
 
 __all__ = ["Cube", "ds9samp", "list_ds9"]
 
@@ -832,7 +832,7 @@ def start(name: str | None = None,
     #
     if client is not None:
         if client in names:
-            name = client
+            clname = client
         else:
             ds9.disconnect()
             raise ValueError(f"client name {client} is not valid")
@@ -842,9 +842,9 @@ def start(name: str | None = None,
             ds9.disconnect()
             raise OSError("Unable to support multiple DS9 SAMP clients. Try setting the client parameter.")
 
-        name = names.pop()
+        clname = names.pop()
 
-    return Connection(ds9=ds9, client=name)
+    return Connection(ds9=ds9, client=clname)
 
 
 def end(connection: Connection) -> None:

--- a/src/ds9samp/__init__.py
+++ b/src/ds9samp/__init__.py
@@ -151,6 +151,27 @@ def add_color(txt):
     return f"\033[1;31m{txt}\033[0;0m"
 
 
+def debug(msg: str) -> None:
+    """Display the debug message.
+
+    Parameters
+    ----------
+    msg
+       The message to display
+
+    See Also
+    --------
+    error, warning
+
+    """
+
+    # This should use the logging infrastructure but I want to see how
+    # it ends up working out first.
+    #
+    lhs = add_color("DEBUG:")
+    print(f"{lhs} {msg}")
+
+
 def error(msg: str) -> None:
     """Display the error message.
 
@@ -161,7 +182,7 @@ def error(msg: str) -> None:
 
     See Also
     --------
-    warning
+    debug, warning
 
     Notes
     -----
@@ -188,7 +209,7 @@ def warning(msg: str) -> None:
 
     See Also
     --------
-    error
+    debug, error
 
     """
 
@@ -200,7 +221,12 @@ def warning(msg: str) -> None:
 
 
 class Connection:
-    """Store the DS9 connection."""
+    """Store the DS9 connection.
+
+    .. versionchanged:: 0.0.6
+       Added the debug option.
+
+    """
 
     def __init__(self,
                  ds9: samp.SAMPIntegratedClient,
@@ -209,6 +235,7 @@ class Connection:
 
         self.ds9 = ds9
         self.client = client
+        self.debug = False
         self.metadata = ds9.get_metadata(client)
         self.timeout = 10
         """Timeout, in seconds (must be an integer)."""
@@ -251,6 +278,11 @@ class Connection:
         tout_str = str(int(tout))
         out = self.ds9.ecall_and_wait(self.client, "ds9.get",
                                       timeout=tout_str, cmd=command)
+
+        if self.debug:
+            # Can we display the output in a structured form?
+            debug(f"ds9.get {command} timeout={tout_str}")
+            debug(str(out))
 
         status = out["samp.status"]
         if status != "samp.ok":
@@ -307,6 +339,11 @@ class Connection:
         tout_str = str(int(tout))
         out = self.ds9.ecall_and_wait(self.client, "ds9.set",
                                       timeout=tout_str, cmd=command)
+
+        if self.debug:
+            # Can we display the output in a structured form?
+            debug(f"ds9.set {command} timeout={tout_str}")
+            debug(str(out))
 
         status = out["samp.status"]
         if status == "samp.ok":

--- a/src/ds9samp/scripts.py
+++ b/src/ds9samp/scripts.py
@@ -10,10 +10,9 @@ Error messages will include color (red) unless
 """
 
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
-import os
 import sys
 
-from ds9samp import ds9samp, list_ds9, VERSION
+from ds9samp import add_color, ds9samp, list_ds9, VERSION
 
 
 def parse(desc):
@@ -39,24 +38,6 @@ def parse(desc):
 def debug(msg):
     """Print out the debug message."""
     print(f"# {msg}")
-
-
-def add_color(txt):
-    """Allow ANSI color escape codes unless NO_COLOR env var is set
-    or sys.stderr is not a TTY.
-
-    See https://no-color.org/
-
-    Is it worth allowing these colors to be customized?
-    """
-
-    if not sys.stderr.isatty():
-        return txt
-
-    if os.getenv('NO_COLOR') is not None:
-        return txt
-
-    return f"\033[1;31m{txt}\033[0;0m"
 
 
 def handle_error(name):

--- a/src/ds9samp/scripts.py
+++ b/src/ds9samp/scripts.py
@@ -88,6 +88,7 @@ Examples:
         if args.debug:
             debug(f"Connected: {ds9}")
             debug(f"Command: {args.command}")
+            ds9.debug = True
 
         out = ds9.get(args.command, timeout=args.timeout)
 
@@ -147,6 +148,7 @@ Examples:
     with ds9samp(client=args.client) as ds9:
         if args.debug:
             debug(f"Connected: {ds9}")
+            ds9.debug = True
 
         ds9.timeout = args.timeout
         for command in commands:


### PR DESCRIPTION
Allow 3D arrays to be sent by `send_array` and retrieved by `retrieve_array`.

The "mode" - e.g. generic cube or a specialized form for RGB, HLS,and HSV - can be set with the `cube` argument to `send_array`.

It's not yet obvious to me whether we can do the equivalent for `retrieve_array`.

Some `get` commands now return data (those that use a temporary URL), although there is significant chance it will not work in all cases (it's not clear to me how to know how to parse the filetype, so handling it generically is "awkward").

Added a debug option to show the SAMP responses to the `ds9.get` and `ds9.set` calls.